### PR TITLE
Individual API calls for each phase

### DIFF
--- a/routes/study_retrieval_routes.py
+++ b/routes/study_retrieval_routes.py
@@ -11,6 +11,9 @@ from services.study_retrieval_service import (
     get_study_id_list,
     get_study_id,
     get_file_from_db,
+    get_learning_phase_from_db,
+    get_waiting_phase_from_db,
+    get_experiment_phase_from_db,
 )
 
 router = APIRouter(prefix="/study", tags=["Study"])
@@ -76,3 +79,30 @@ async def export_config_file(
 ) -> StudyConfigResponse:
     """Returns Full Configuration File as a JSON"""
     return await get_config_file(study_id=study_id, conn=conn)
+
+
+@router.get("/learning_phase/{study_id}")
+async def get_learning_phase(
+    study_id: uuid.UUID,
+    conn: AsyncSession = Depends(get_db_session),
+):
+    """Returns the Learning Phase configuration for the study."""
+    return await get_learning_phase_from_db(study_id=study_id, conn=conn)
+
+
+@router.get("/waiting_phase/{study_id}")
+async def get_waiting_phase(
+    study_id: uuid.UUID,
+    conn: AsyncSession = Depends(get_db_session),
+):
+    """Returns the Waiting Phase configuration for the study"""
+    return await get_waiting_phase_from_db(study_id=study_id, conn=conn)
+
+
+@router.get("/experiment_phase/{study_id}")
+async def get_experiment_phase(
+    study_id: uuid.UUID,
+    conn: AsyncSession = Depends(get_db_session),
+):
+    """Returns the Experiment Phase configuration for the study."""
+    return await get_experiment_phase_from_db(study_id=study_id, conn=conn)

--- a/services/study_retrieval_service.py
+++ b/services/study_retrieval_service.py
@@ -174,3 +174,61 @@ async def get_config_file(
             has_survey=study.conclusion.survey,
         ),
     )
+
+async def get_learning_phase_from_db(
+    study_id: uuid.UUID, conn: AsyncSession
+) -> LearningPhase:
+    stmt = (
+        select(StudyConfiguration)
+        .options(selectinload(StudyConfiguration.learning))
+        .where(StudyConfiguration.id == study_id)
+    )
+    result = await conn.execute(stmt)
+    study = result.scalar_one_or_none()
+    if not study or not study.learning:
+        raise HTTPException(status_code=404, detail="Learning phase not found")
+    learning = study.learning
+    return LearningPhase(
+        display_duration=learning.display_duration,
+        pause_duration=learning.pause_duration,
+        display_method=learning.display_method,
+    )
+
+
+async def get_waiting_phase_from_db(
+    study_id: uuid.UUID, conn: AsyncSession
+) -> WaitPhase:
+    stmt = (
+        select(StudyConfiguration)
+        .options(selectinload(StudyConfiguration.wait))
+        .where(StudyConfiguration.id == study_id)
+    )
+    result = await conn.execute(stmt)
+    study = result.scalar_one_or_none()
+    if not study or not study.wait:
+        raise HTTPException(status_code = 404, detail="Waiting phase not found")
+    wait = study.wait
+    return WaitPhase(
+        display_duration=wait.display_duration,
+    )
+
+
+async def get_experiment_phase_from_db(
+    study_id: uuid.UUID, conn: AsyncSession
+) -> ExperimentPhase:
+    stmt = (
+        select(StudyConfiguration)
+        .options(selectinload(StudyConfiguration.experiment))
+        .where(StudyConfiguration.id == study_id)
+    )
+    result = await conn.execute(stmt)
+    study = result.scalar_one_or_none()
+    if not study or not study.experiment:
+        raise HTTPException(status_code=404, detail="Experiment phase not found")
+    experiment = study.experiment
+    return ExperimentPhase(
+        display_duration=experiment.display_duration,
+        pause_duration=experiment.pause_duration,
+        display_method=experiment.display_method,
+        response_method=experiment.response_method,
+    )

--- a/tests/integration/test_get.py
+++ b/tests/integration/test_get.py
@@ -21,3 +21,52 @@ async def test_get_study_config():
         json_data = response.json()
         parsed = StudyConfigResponse(**json_data)
         assert parsed
+
+@pytest.mark.asyncio
+async def test_get_learning_phase():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        study_response = await client.get("/study/study_ids")
+        assert study_response.status_code == 200
+        study_id = study_response.json()
+
+        response = await client.get(f"/study/learning_phase/{study_id[0]}")
+        assert response.status_code == 200
+        json_data = response.json()
+        assert "display_duration" in json_data
+        assert "pause_duration" in json_data
+        assert "display_method" in json_data
+
+
+@pytest.mark.asyncio
+async def test_get_waiting_phase():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        study_response = await client.get("/study/study_ids")
+        assert study_response.status_code == 200
+        study_id = study_response.json()
+
+        response = await client.get(f"/study/waiting_phase/{study_id[0]}")
+        assert response.status_code == 200
+        json_data = response.json()
+        assert "display_duration" in json_data
+
+
+@pytest.mark.asyncio
+async def test_get_experiment_phase():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        study_response = await client.get("/study/study_ids")
+        assert study_response.status_code == 200
+        study_id = study_response.json()
+
+        response = await client.get(f"/study/experiment_phase/{study_id[0]}")
+        assert response.status_code == 200
+        json_data = response.json()
+        assert "display_duration" in json_data
+        assert "pause_duration" in json_data
+        assert "display_method" in json_data
+        assert "response_method" in json_data


### PR DESCRIPTION
- `study_retrieval_routes.py`: Added new GET endpoints for learning, waiting, and experiment phases using StudyID.
- `study_retrieval_service.py`: Implemented functions to query and return phase configurations from the database.
- `test_get.py`: Added tests to verify the new study phase endpoints return the correct data for each phase.