### PR TITLE
feat: Added image urls to learning phase response

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "python.testing.pytestArgs": [
-        "tests"
+        "."
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true

--- a/routes/study_retrieval_routes.py
+++ b/routes/study_retrieval_routes.py
@@ -5,13 +5,16 @@ from fastapi.responses import StreamingResponse
 from db.client import get_db_session
 from sqlalchemy.ext.asyncio import AsyncSession
 from models.uploaded_files_model import UploadedFiles
+from services.r2_client import get_r2_client
+from settings import Settings, get_settings
+from botocore.client import BaseClient
 from schemas.study_config_response_schema import StudyConfigResponse
 from services.study_retrieval_service import (
     get_config_file,
     get_study_id_list,
     get_study_id,
     get_file_from_db,
-    get_learning_phase_from_db,
+    get_learning_phase_data,
     get_waiting_phase_from_db,
     get_experiment_phase_from_db,
 )
@@ -85,9 +88,11 @@ async def export_config_file(
 async def get_learning_phase(
     study_id: uuid.UUID,
     conn: AsyncSession = Depends(get_db_session),
+    client: BaseClient = Depends(get_r2_client),
+    settings: Settings = Depends(get_settings)
 ):
     """Returns the Learning Phase configuration for the study."""
-    return await get_learning_phase_from_db(study_id=study_id, conn=conn)
+    return await get_learning_phase_data(study_id=study_id, conn=conn, client=client, settings=settings)
 
 
 @router.get("/waiting_phase/{study_id}")

--- a/schemas/study_config_response_schema.py
+++ b/schemas/study_config_response_schema.py
@@ -10,6 +10,7 @@ class LearningPhase(BaseModel):
     display_duration: int
     pause_duration: int
     display_method: DisplayMethodEnum
+    image_urls: list[str]
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/tests/integration/test_get.py
+++ b/tests/integration/test_get.py
@@ -37,7 +37,7 @@ async def test_get_learning_phase():
         assert "display_duration" in json_data
         assert "pause_duration" in json_data
         assert "display_method" in json_data
-
+        assert "image_urls" in json_data
 
 @pytest.mark.asyncio
 async def test_get_waiting_phase():
@@ -52,7 +52,6 @@ async def test_get_waiting_phase():
         assert response.status_code == 200
         json_data = response.json()
         assert "display_duration" in json_data
-
 
 @pytest.mark.asyncio
 async def test_get_experiment_phase():


### PR DESCRIPTION
Updated Learning Phase Retrieval Endpoint
- Added List of Image URLs to response model
- Abstracted all learning phase related methods into a single method to be called by the endpoint
- Added DI for settings and r2 client to pass into image retrieval methods into learning phase endpoint