### PR TITLE
feat: Display Image For Experiment Phase

### DIFF
--- a/routes/study_retrieval_routes.py
+++ b/routes/study_retrieval_routes.py
@@ -17,8 +17,7 @@ from services.study_retrieval_service import (
     get_survey_id,
     get_survey_questions_from_db,
     get_learning_phase_data,
-    get_waiting_phase_from_db,
-    get_experiment_phase_from_db,
+    get_experiment_phase_from_db, get_experiment_phase_data,
 )
 
 router = APIRouter(prefix="/study", tags=["Study"])
@@ -109,13 +108,16 @@ async def get_learning_phase(
     return await get_learning_phase_data(study_id=study_id, conn=conn, client=client, settings=settings)
 
 
-@router.get("/waiting_phase/{study_id}")
-async def get_waiting_phase(
+@router.get("/experiment_phase_images/{study_id}")
+async def get_experiment_phase_images(
     study_id: uuid.UUID,
     conn: AsyncSession = Depends(get_db_session),
+    client: BaseClient = Depends(get_r2_client),
+    settings: Settings = Depends(get_settings)
 ):
-    """Returns the Waiting Phase configuration for the study"""
-    return await get_waiting_phase_from_db(study_id=study_id, conn=conn)
+    """ Returns the Experiment Phase configuration along with presigned URLs for experiment images. """
+    return await get_experiment_phase_data(study_id, conn, client, settings)
+
 
 
 @router.get("/experiment_phase/{study_id}")

--- a/routes/study_retrieval_routes.py
+++ b/routes/study_retrieval_routes.py
@@ -108,7 +108,7 @@ async def get_learning_phase(
     return await get_learning_phase_data(study_id=study_id, conn=conn, client=client, settings=settings)
 
 
-@router.get("/experiment_phase_images/{study_id}")
+@router.get("/experiment_phase/{study_id}")
 async def get_experiment_phase_images(
     study_id: uuid.UUID,
     conn: AsyncSession = Depends(get_db_session),
@@ -117,13 +117,3 @@ async def get_experiment_phase_images(
 ):
     """ Returns the Experiment Phase configuration along with presigned URLs for experiment images. """
     return await get_experiment_phase_data(study_id, conn, client, settings)
-
-
-
-@router.get("/experiment_phase/{study_id}")
-async def get_experiment_phase(
-    study_id: uuid.UUID,
-    conn: AsyncSession = Depends(get_db_session),
-):
-    """Returns the Experiment Phase configuration for the study."""
-    return await get_experiment_phase_from_db(study_id=study_id, conn=conn)

--- a/routes/study_retrieval_routes.py
+++ b/routes/study_retrieval_routes.py
@@ -5,7 +5,7 @@ from fastapi.responses import StreamingResponse
 from db.client import get_db_session
 from sqlalchemy.ext.asyncio import AsyncSession
 from models.uploaded_files_model import UploadedFiles
-from schemas.study_config_response_schema import StudyConfigResponse, SurveyQuestions
+from schemas.study_config_response_schema import SurveyQuestions
 from services.r2_client import get_r2_client
 from settings import Settings, get_settings
 from botocore.client import BaseClient

--- a/routes/study_retrieval_routes.py
+++ b/routes/study_retrieval_routes.py
@@ -117,3 +117,4 @@ async def get_experiment_phase_images(
 ):
     """ Returns the Experiment Phase configuration along with presigned URLs for experiment images. """
     return await get_experiment_phase_data(study_id, conn, client, settings)
+

--- a/routes/study_retrieval_routes.py
+++ b/routes/study_retrieval_routes.py
@@ -17,7 +17,7 @@ from services.study_retrieval_service import (
     get_survey_id,
     get_survey_questions_from_db,
     get_learning_phase_data,
-    get_experiment_phase_from_db, get_experiment_phase_data,
+    get_experiment_phase_data,
 )
 
 router = APIRouter(prefix="/study", tags=["Study"])

--- a/services/study_retrieval_service.py
+++ b/services/study_retrieval_service.py
@@ -295,13 +295,7 @@ async def get_experiment_phase_from_db(
     study = result.scalar_one_or_none()
     if not study or not study.experiment:
         raise HTTPException(status_code=404, detail="Experiment phase not found")
-    experiment = study.experiment
-    return ExperimentPhase(
-        display_duration=experiment.display_duration,
-        pause_duration=experiment.pause_duration,
-        display_method=experiment.display_method,
-        response_method=experiment.response_method,
-    )
+    return study.experiment
 
 
 async def get_experiment_phase_data(study_id: uuid.UUID, conn: AsyncSession, client: BaseClient, settings: Settings):

--- a/services/study_retrieval_service.py
+++ b/services/study_retrieval_service.py
@@ -20,7 +20,7 @@ from schemas.study_config_response_schema import (
     LearningPhase,
     WaitPhase,
     ExperimentPhase,
-    ConclusionPhase, 
+    ConclusionPhase,
     SurveyQuestions
 )
 from services.r2_service import generate_url_list
@@ -39,6 +39,7 @@ async def get_study_id_list(conn: AsyncSession) -> list[uuid.UUID]:
     except Exception as e:
         raise HTTPException(404, detail=str(e))
 
+
 async def get_study_id(study_code: str, conn: AsyncSession) -> uuid.UUID:
     """Returns the first matching Study ID from a submitted 6-digit study code"""
     try:
@@ -50,6 +51,7 @@ async def get_study_id(study_code: str, conn: AsyncSession) -> uuid.UUID:
                 return study.id
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
+
 
 async def get_file_from_db(
     study_id: uuid.UUID,
@@ -103,8 +105,9 @@ async def get_file_from_db(
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
 
-async def get_image_list(study_id:uuid.UUID, conn:AsyncSession, column:ImageListColumn) -> list[str]:
-    image_list_column = getattr(UploadedFiles,column.value)
+
+async def get_image_list(study_id: uuid.UUID, conn: AsyncSession, column: ImageListColumn) -> list[str]:
+    image_list_column = getattr(UploadedFiles, column.value)
     try:
         stmt = (
             select(image_list_column)
@@ -117,9 +120,10 @@ async def get_image_list(study_id:uuid.UUID, conn:AsyncSession, column:ImageList
     except Exception as e:
         raise HTTPException(404, detail=str(e))
 
+
 async def get_config_file(
     study_id: uuid.UUID, conn: AsyncSession,
-    
+
 ) -> StudyConfigResponse:
     """
     Returns Configuration File
@@ -142,20 +146,21 @@ async def get_config_file(
         HTTPException: 500: Missing file upload data
         HTTPException: 500: Missing phase configuration
     """
-    
+
     stmt = (
         select(StudyConfiguration)
         .options(
             selectinload(StudyConfiguration.learning),
             selectinload(StudyConfiguration.wait),
             selectinload(StudyConfiguration.experiment),
+            # selectinload(StudyConfiguration.survey),
             selectinload(StudyConfiguration.files),
             selectinload(StudyConfiguration.conclusion),
             selectinload(StudyConfiguration.demographics)
             .selectinload(UserSurveyConfig.questions)
         )
 
-        .where(StudyConfiguration.id == study_id)     
+        .where(StudyConfiguration.id == study_id)
     )
 
     result = await conn.execute(stmt)
@@ -168,7 +173,7 @@ async def get_config_file(
         raise HTTPException(status_code=500, detail="Missing file upload data.")
     if not study.learning or not study.wait or not study.experiment:
         raise HTTPException(status_code=500, detail="Missing phase configuration.")
-  
+
 
     return StudyConfigResponse(
         files=FileUploads(
@@ -200,7 +205,7 @@ async def get_config_file(
     )
 
 async def get_survey_id(
-        study_id:uuid.UUID, conn:AsyncSession        
+        study_id:uuid.UUID, conn:AsyncSession
 ) -> uuid.UUID:
     """Returns matching Survey ID from corresponding Study ID"""
     try:
@@ -210,10 +215,10 @@ async def get_survey_id(
         )
         result = await conn.execute(stmt)
         return result.scalar_one_or_none()
-    
+
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
-    
+
 
 async def get_survey_questions_from_db(
         survey_id:uuid.UUID, conn:AsyncSession
@@ -229,11 +234,12 @@ async def get_survey_questions_from_db(
         return SurveyQuestions(questions=survey_questions)
 
     except Exception as e:
-        print(str(e))  
-    
+        print(str(e))
+
+
 
 async def get_learning_phase_from_db(
-    study_id: uuid.UUID, conn: AsyncSession
+        study_id: uuid.UUID, conn: AsyncSession
 ) -> LearningPhase:
     stmt = (
         select(StudyConfiguration)
@@ -246,16 +252,18 @@ async def get_learning_phase_from_db(
         raise HTTPException(status_code=404, detail="Learning phase not found")
     return study.learning
 
-async def get_learning_phase_data(study_id: uuid.UUID, conn: AsyncSession, client:BaseClient, settings:Settings):
-    learning = await get_learning_phase_from_db(study_id,conn)
-    image_list= await get_image_list(study_id,conn,ImageListColumn.LEARNING)
-    generated_urls = generate_url_list(client, settings.r2_bucket_name,image_list)
+
+async def get_learning_phase_data(study_id: uuid.UUID, conn: AsyncSession, client: BaseClient, settings: Settings):
+    learning = await get_learning_phase_from_db(study_id, conn)
+    image_list = await get_image_list(study_id, conn, ImageListColumn.LEARNING)
+    generated_urls = generate_url_list(client, settings.r2_bucket_name, image_list)
     return LearningPhase(
         display_duration=learning.display_duration,
         pause_duration=learning.pause_duration,
         display_method=learning.display_method,
         image_urls=generated_urls
     )
+
 
 async def get_waiting_phase_from_db(
     study_id: uuid.UUID, conn: AsyncSession
@@ -273,6 +281,7 @@ async def get_waiting_phase_from_db(
     return WaitPhase(
         display_duration=wait.display_duration,
     )
+
 
 async def get_experiment_phase_from_db(
     study_id: uuid.UUID, conn: AsyncSession
@@ -292,4 +301,17 @@ async def get_experiment_phase_from_db(
         pause_duration=experiment.pause_duration,
         display_method=experiment.display_method,
         response_method=experiment.response_method,
+    )
+
+
+async def get_experiment_phase_data(study_id: uuid.UUID, conn: AsyncSession, client: BaseClient, settings: Settings):
+    experiment = await get_experiment_phase_from_db(study_id, conn)
+    image_list = await get_image_list(study_id, conn, ImageListColumn.EXPERIMENT)
+    generated_urls = generate_url_list(client, settings.r2_bucket_name, image_list)
+    return ExperimentPhase(
+        display_duration=experiment.display_duration,
+        pause_duration=experiment.pause_duration,
+        display_method=experiment.display_method,
+        response_method=experiment.response_method,
+        image_urls=generated_urls
     )


### PR DESCRIPTION
### Description
This PR adds backend support to fetch and serve presigned image URLs for the **Experiment Phase** of a study. The implementation mirrors the Learning Phase logic using Cloudflare R2 (S3-compatible) storage.

### Changes Made
- Added new service method `get_experiment_phase_data` in `study_retrieval_service.py` to:
  - Fetch experiment image list from DB.
  - Generate presigned Cloudflare URLs using `generate_url_list`.
  - Return full experiment phase config with `image_urls` field.

- Updated GET endpoint:
  - `GET /study/experiment_phase/{study_id}`
  - Returns experiment phase config with image URLs.

### Testing
- Verified endpoint returns valid presigned URLs.
- Checked edge cases:
  - Study not found.

---